### PR TITLE
[FIX EVENT_TYPES]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,23 @@
-const EVENT_TYPES = Symbol('eventTypes');
+const EVENT_TYPES = '__eventTypes__';
 
 const validateEventType = (
   emitterInstance,
   eventType = '',
 ) => {
+  if (process.env.NODE_ENV !== 'development') {
+    return;
+  }
+
   const eventTypes = emitterInstance[EVENT_TYPES];
+
+  if (!eventTypes) {
+    const msg = [
+      '[ super-emitter ] emitter instance',
+      'has no registered types',
+    ].join(' ');
+    throw new Error(msg);
+  }
+
   if (eventTypes.has(eventType)) {
     return;
   }


### PR DESCRIPTION
The `EVENT_TYPES` symbol was causing issues when super-emitter is cleared from the require cache and loaded anew. This is due to different symbols references being created. To get around this we have to use a string as the property name.